### PR TITLE
Rename JSONDATA

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@
 
 var jsonp = require('jsonp')
 
-JSONDATA = 'https://yubinbango.github.io/yubinbango-data/data';
+YUBINBANGODATA = 'https://yubinbango.github.io/yubinbango-data/data';
 CACHE = [];
 
 
@@ -103,7 +103,7 @@ var parse = function(nzip, data, callback){
 
 fetchRemote = function (nzip, callback) {
   var zip3 = nzip.substr(0,3);
-  var url = JSONDATA+'/'+zip3+'.js';
+  var url = YUBINBANGODATA+'/'+zip3+'.js';
   jsonp(url, { name: '$yubin'}, function(error, data) {
     if (!error) {
       CACHE[zip3] = data;


### PR DESCRIPTION
When I use it with vite I get the following error:

```
JSONDATA is not defined

at node_modules/japan-postal-code/index.js (http://localhost:3000/_nuxt/node_modules/.cache/vite/client/deps/japan-postal-code.js?v=f0935111:367:14)
at __require (http://localhost:3000/_nuxt/node_modules/.cache/vite/client/deps/chunk-IVLCYF2H.js?v=f0935111:5:50)
at http://localhost:3000/_nuxt/node_modules/.cache/vite/client/deps/japan-postal-code.js?v=f0935111:482:16
```